### PR TITLE
Add Doppler session monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,90 @@
 # Doppler Session Micro-Frontend
+
+## Doppler Session Polling
+
+Basic behavior of DopplerSession micro-frontend:
+
+```mermaid
+sequenceDiagram
+  participant Browser
+  participant DopplerSessionMFE
+  participant window
+  participant DopplerMVC
+
+  Browser->>+DopplerSessionMFE: start
+  DopplerSessionMFE->>window: WRITE dopplerSessionState = { status = "unknown" }
+  DopplerSessionMFE-)window:dispatchEvent("doppler-session-state-update")
+  alt User does not have a session in Doppler
+    DopplerSessionMFE->>+DopplerMVC: GetUserData(cookie)
+    DopplerMVC-->>-DopplerSessionMFE: Error
+    DopplerSessionMFE->>window: WRITE dopplerSessionState = { status: "non-authenticated" }
+    DopplerSessionMFE-)window: dispatchEvent("doppler-session-state-update", { status: "non-authenticated" })
+  else User has a session in Doppler
+    DopplerSessionMFE->>+DopplerMVC: GetUserData(cookie)
+    DopplerMVC-->>-DopplerSessionMFE: UserData
+    DopplerSessionMFE->>window: WRITE dopplerSessionState = { status: "authenticated", . . . }
+    DopplerSessionMFE-)window: dispatchEvent("doppler-session-state-update", { status: "authenticated", . . . })
+  end
+  deactivate DopplerSessionMFE
+
+  loop Each 5 min
+  Browser->>+DopplerSessionMFE: interval
+  alt User does not have a session in Doppler
+    DopplerSessionMFE->>+DopplerMVC: GetUserData(cookie)
+    DopplerMVC-->>-DopplerSessionMFE: Error
+    DopplerSessionMFE->>window: WRITE dopplerSessionState = { status: "non-authenticated" }
+    DopplerSessionMFE-)window: dispatchEvent("doppler-session-state-update", { status: "non-authenticated" })
+  else User has a session in Doppler
+    DopplerSessionMFE->>+DopplerMVC: GetUserData(cookie)
+    DopplerMVC-->>-DopplerSessionMFE: UserData
+    DopplerSessionMFE->>window: WRITE dopplerSessionState = { status: "authenticated", . . . }
+    DopplerSessionMFE-)window: dispatchEvent("doppler-session-state-update", { status: "authenticated", . . . })
+  end
+  deactivate DopplerSessionMFE
+  end
+```
+
+Opening a private page in a WebApp micro-frontend:
+
+```mermaid
+sequenceDiagram
+  participant Browser
+  participant WebAppMFE
+  participant window
+
+  Browser->>+WebAppMFE: start
+  WebAppMFE-)window: addEventListener ("doppler-session-state-update", . . .)
+  alt WebAppMFE loaded before DopplerSessionMFE be ready
+    WebAppMFE->>+window: READ dopplerSessionState
+    window-->>-WebAppMFE: READ undefined [*]
+    Note right of WebAppMFE: Assumes { status = "unknown" }
+  else DopplerSessionMFE was ready before load WebAppMFE
+    WebAppMFE->>+window: READ dopplerSessionState
+    window-->>-WebAppMFE: READ { status = "unknown" } [*]
+  end
+  WebAppMFE-->>-Browser: Show spinner
+
+  alt WebAppMFE loaded before DopplerSessionMFE be ready
+    window->>+WebAppMFE: on "doppler-session-state-update"
+    WebAppMFE->>+window: READ dopplerSessionState
+    window-->>-WebAppMFE: READ { status = "unknown" } [*]
+    WebAppMFE-->>-Browser: Show spinner
+  end
+
+  alt User does not have a session in Doppler
+    window->>+WebAppMFE: on "doppler-session-state-update"
+    WebAppMFE->>+window: READ dopplerSessionState
+    window-->>-WebAppMFE: READ { status = "non-authenticated" }
+    WebAppMFE-->>-Browser: Redirect to Login
+  else User has a session in Doppler
+    window->>+WebAppMFE: on "doppler-session-state-update"
+    WebAppMFE->>+window: READ dopplerSessionState
+    window-->>-WebAppMFE: READ { status = "authenticated", . . . }
+    WebAppMFE-->>-Browser: Render the page
+  end
+```
+
+`[*]` At the moment, the first answers for `READ dopplerSessionState` will always
+be `null` or `{ status = "unknown" }`. But in the future, _DopplerSession micro-
+frontend_ is going to be improved to cache the last session state (for example,
+in local storage), so the first steps could be omitted.

--- a/src/app-session/DopplerSessionStateMonitorPollingImpl.ts
+++ b/src/app-session/DopplerSessionStateMonitorPollingImpl.ts
@@ -1,0 +1,53 @@
+import {
+  DopplerSessionState,
+  DopplerSessionStateMonitor,
+} from "./abstractions";
+
+export class DopplerSessionStateMonitorPollingImpl
+  implements DopplerSessionStateMonitor
+{
+  private readonly _setInterval: (
+    handler: TimerHandler,
+    timeout: number
+  ) => number;
+  private readonly _dopplerLegacyClient;
+  private readonly _keepAliveMilliseconds;
+
+  public onSessionUpdate: (sessionState: DopplerSessionState) => void =
+    () => {};
+
+  constructor({
+    setInterval,
+    dopplerLegacyClient,
+    keepAliveMilliseconds,
+  }: {
+    setInterval: (handler: TimerHandler, timeout: number) => number;
+    dopplerLegacyClient: any;
+    keepAliveMilliseconds: number;
+  }) {
+    this._setInterval = setInterval;
+    this._dopplerLegacyClient = dopplerLegacyClient;
+    this._keepAliveMilliseconds = keepAliveMilliseconds;
+  }
+
+  private async fetchDopplerUserData(): Promise<DopplerSessionState> {
+    const result = await this._dopplerLegacyClient.getDopplerUserData();
+    return result.success
+      ? {
+          status: "authenticated",
+          jwtToken: result.value.jwtToken,
+          dopplerAccountName: result.value.user.email,
+          unlayerUserId: result.value.unlayerUser.id,
+          unlayerUserSignature: result.value.unlayerUser.signature,
+        }
+      : { status: "non-authenticated" };
+  }
+
+  async start(): Promise<void> {
+    this.onSessionUpdate({ status: "unknown" });
+    this._setInterval(async () => {
+      this.onSessionUpdate(await this.fetchDopplerUserData());
+    }, this._keepAliveMilliseconds);
+    this.onSessionUpdate(await this.fetchDopplerUserData());
+  }
+}

--- a/src/app-session/DopplerSessionStateMonitorPollingImpl.ts
+++ b/src/app-session/DopplerSessionStateMonitorPollingImpl.ts
@@ -39,6 +39,7 @@ export class DopplerSessionStateMonitorPollingImpl
           dopplerAccountName: result.value.user.email,
           unlayerUserId: result.value.unlayerUser.id,
           unlayerUserSignature: result.value.unlayerUser.signature,
+          lang: result.value.user.lang === "en" ? "en" : "es",
         }
       : { status: "non-authenticated" };
   }

--- a/src/app-session/abstractions.ts
+++ b/src/app-session/abstractions.ts
@@ -1,0 +1,19 @@
+export type AuthenticatedDopplerSessionState = {
+  status: "authenticated";
+  jwtToken: string;
+  dopplerAccountName: string;
+  unlayerUserId: string;
+  unlayerUserSignature: string;
+};
+
+export type DopplerSessionState =
+  | { status: "unknown" }
+  | { status: "non-authenticated" }
+  | AuthenticatedDopplerSessionState;
+
+export type DopplerSessionStatus = DopplerSessionState["status"];
+
+export interface DopplerSessionStateMonitor {
+  onSessionUpdate: (sessionState: DopplerSessionState) => void;
+  start(): void;
+}

--- a/src/app-session/abstractions.ts
+++ b/src/app-session/abstractions.ts
@@ -4,6 +4,7 @@ export type AuthenticatedDopplerSessionState = {
   dopplerAccountName: string;
   unlayerUserId: string;
   unlayerUserSignature: string;
+  lang: "en" | "es";
 };
 
 export type DopplerSessionState =

--- a/src/app-session/index.test.tsx
+++ b/src/app-session/index.test.tsx
@@ -127,6 +127,7 @@ describe(runMonitor.name, () => {
       jwtToken: expect.any(String),
       unlayerUserId: expect.any(String),
       unlayerUserSignature: expect.any(String),
+      lang: expect.any(String),
     });
     expect(window.dispatchEvent).toHaveBeenCalledTimes(2);
     expect(lastDispatchedEventRef.value).toBeInstanceOf(CustomEvent);
@@ -147,6 +148,7 @@ describe(runMonitor.name, () => {
       jwtToken: expect.any(String),
       unlayerUserId: expect.any(String),
       unlayerUserSignature: expect.any(String),
+      lang: expect.any(String),
     });
     expect(window.dispatchEvent).toHaveBeenCalledTimes(2);
 

--- a/src/app-session/index.test.tsx
+++ b/src/app-session/index.test.tsx
@@ -1,0 +1,170 @@
+import { runMonitor } from ".";
+import { timeout } from "../common/utils";
+import {
+  DopplerLegacyClient,
+  GetDopplerUserDataResult,
+} from "../doppler-legacy-client/abstractions";
+
+const demoDopplerUserData = {
+  jwtToken: "session_token",
+  user: {
+    email: "user@email",
+    fullname: "user.fullname",
+    lang: "es",
+    avatar: {
+      text: "NN",
+      color: "#99CFB8",
+    },
+  },
+  unlayerUser: {
+    id: "user_id",
+    signature: "user_signature",
+  },
+};
+
+const createWindowDouble = () => {
+  let intervalHandler: Function = () => {};
+  let lastDispatchedEventRef = {
+    value: null as any,
+  };
+  return {
+    runIntervalEvent: () => intervalHandler(),
+    lastDispatchedEventRef,
+    window: {
+      setInterval: jest.fn((handler: Function) => {
+        intervalHandler = handler;
+      }),
+      dispatchEvent: jest.fn((event) => {
+        lastDispatchedEventRef.value = event;
+      }),
+    } as unknown as Window,
+  };
+};
+
+const createDopplerLegacyClientDouble = () => {
+  let getDopplerUserDataResolve: (result: GetDopplerUserDataResult) => void;
+  const runResultResolvingGetDopplerUserData = async (
+    result: GetDopplerUserDataResult
+  ) => {
+    getDopplerUserDataResolve(result);
+    await timeout(0);
+  };
+
+  const runErrorResolvingGetDopplerUserData = async () =>
+    runResultResolvingGetDopplerUserData({
+      success: false,
+      error: {
+        userDataNotAvailable: true,
+        innerError: new Error(),
+      },
+    });
+
+  const runSuccessResolvingGetDopplerUserData = async () =>
+    runResultResolvingGetDopplerUserData({
+      success: true,
+      value: {
+        ...demoDopplerUserData,
+      },
+    });
+
+  return {
+    dopplerLegacyClient: {
+      getDopplerUserData: jest.fn(
+        () =>
+          new Promise((resolve) => {
+            getDopplerUserDataResolve = resolve;
+          })
+      ),
+    } as DopplerLegacyClient,
+    runErrorResolvingGetDopplerUserData,
+    runSuccessResolvingGetDopplerUserData,
+  };
+};
+
+describe(runMonitor.name, () => {
+  it("should work recurrently as expected 😛", async () => {
+    // Arrange
+    const keepAliveMilliseconds = 600000;
+    const { window, lastDispatchedEventRef, runIntervalEvent } =
+      createWindowDouble();
+    const {
+      dopplerLegacyClient,
+      runErrorResolvingGetDopplerUserData,
+      runSuccessResolvingGetDopplerUserData,
+    } = createDopplerLegacyClientDouble();
+
+    // Act
+    // Initialization
+    runMonitor({
+      window,
+      dopplerLegacyClient,
+      keepAliveMilliseconds,
+    });
+
+    // Assert
+    // After initialization, the status should be `unknown` while we look forward
+    // to the server response for getDopplerUserData.
+    expect(dopplerLegacyClient.getDopplerUserData).toHaveBeenCalledTimes(1);
+    expect(window.dopplerSessionState).toEqual({
+      status: "unknown",
+    });
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(lastDispatchedEventRef.value).toBeInstanceOf(CustomEvent);
+    expect(lastDispatchedEventRef.value.type).toBe(
+      "doppler-session-state-update"
+    );
+
+    // Act
+    // Server responds successfully for getDopplerUserData
+    await runSuccessResolvingGetDopplerUserData();
+
+    // Assert
+    // After a successful response for getDopplerUserData, the status should be
+    // `authenticated`.
+    expect(window.dopplerSessionState).toEqual({
+      status: "authenticated",
+      dopplerAccountName: expect.any(String),
+      jwtToken: expect.any(String),
+      unlayerUserId: expect.any(String),
+      unlayerUserSignature: expect.any(String),
+    });
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(2);
+    expect(lastDispatchedEventRef.value).toBeInstanceOf(CustomEvent);
+    expect(lastDispatchedEventRef.value.type).toBe(
+      "doppler-session-state-update"
+    );
+
+    // Act
+    // The time has elapsed and the interval is executed
+    runIntervalEvent();
+
+    // Assert
+    // After interval is executed, the status should be the same as before while
+    // we look forward to the server response for getDopplerUserData.
+    expect(window.dopplerSessionState).toEqual({
+      status: "authenticated",
+      dopplerAccountName: expect.any(String),
+      jwtToken: expect.any(String),
+      unlayerUserId: expect.any(String),
+      unlayerUserSignature: expect.any(String),
+    });
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(2);
+
+    // Act
+    // Server responds with an error for getDopplerUserData, for example if the
+    // user logs off in another tab
+    await runErrorResolvingGetDopplerUserData();
+
+    // Assert
+    // After an error response for getDopplerUserData, the status should be
+    // `non-authenticated`.
+    expect(window.dopplerSessionState).toEqual({
+      status: "non-authenticated",
+    });
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(3);
+    expect(lastDispatchedEventRef.value).toBeInstanceOf(CustomEvent);
+    expect(lastDispatchedEventRef.value.type).toBe(
+      "doppler-session-state-update"
+    );
+  });
+});

--- a/src/app-session/index.tsx
+++ b/src/app-session/index.tsx
@@ -1,0 +1,31 @@
+import { DopplerSessionState } from "./abstractions";
+import { DopplerSessionStateMonitorPollingImpl } from "./DopplerSessionStateMonitorPollingImpl";
+import { DopplerLegacyClient } from "../doppler-legacy-client/abstractions";
+import { DOPPLER_SESSION_STATE_UPDATE_EVENT_TYPE } from "../public-api";
+
+export const runMonitor = ({
+  window,
+  dopplerLegacyClient,
+  keepAliveMilliseconds,
+}: {
+  window: Window;
+  dopplerLegacyClient: DopplerLegacyClient;
+  keepAliveMilliseconds: number;
+}) => {
+  const sessionStateMonitor = new DopplerSessionStateMonitorPollingImpl({
+    setInterval: window.setInterval.bind(window),
+    dopplerLegacyClient,
+    keepAliveMilliseconds,
+  });
+
+  sessionStateMonitor.onSessionUpdate = (sessionState: DopplerSessionState) => {
+    window.dopplerSessionState = sessionState;
+    window.dispatchEvent(
+      new CustomEvent(DOPPLER_SESSION_STATE_UPDATE_EVENT_TYPE, {
+        detail: sessionState,
+      })
+    );
+  };
+
+  sessionStateMonitor.start();
+};

--- a/src/common/abstractions.ts
+++ b/src/common/abstractions.ts
@@ -1,0 +1,12 @@
+type SuccessResult<TResult> = TResult extends void
+  ? { success: true }
+  : { success: true; value: TResult };
+
+type ErrorResult<TExpectedError> = { success: false; error: TExpectedError };
+
+export type Result<
+  TResult = void,
+  TExpectedError = void
+> = TExpectedError extends void
+  ? SuccessResult<TResult>
+  : SuccessResult<TResult> | ErrorResult<TExpectedError>;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,0 +1,2 @@
+export const timeout = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/doppler-legacy-client/DopplerLegacyClientDummyImpl.ts
+++ b/src/doppler-legacy-client/DopplerLegacyClientDummyImpl.ts
@@ -1,0 +1,44 @@
+import { timeout } from "../common/utils";
+import { DopplerLegacyClient, GetDopplerUserDataResult } from "./abstractions";
+
+let counter = 0;
+
+export class DopplerLegacyClientDummyImpl implements DopplerLegacyClient {
+  public getDopplerUserData: () => Promise<GetDopplerUserDataResult> =
+    async () => {
+      try {
+        console.log("Begin getDopplerUserData...");
+        await timeout(3000);
+        const result = {
+          success: true as const,
+          value: {
+            jwtToken: `jwtToken-${counter++}`,
+            user: {
+              email: "test@test.com",
+              fullname: "Juan Perez",
+              lang: "es",
+              avatar: {
+                text: "JP",
+                color: "#99CFB8",
+              },
+            },
+            unlayerUser: {
+              id: "local_105690",
+              signature:
+                "c3a76d3bd1d1216fb538c22cc970db4bc31d09db091c861f7d10b0ced3a4348b",
+            },
+          },
+        };
+        console.log("End getDopplerUserData", { result });
+        return result;
+      } catch (e) {
+        return {
+          success: false,
+          error: {
+            userDataNotAvailable: true,
+            innerError: e,
+          },
+        };
+      }
+    };
+}

--- a/src/doppler-legacy-client/DopplerLegacyClientImpl.test.ts
+++ b/src/doppler-legacy-client/DopplerLegacyClientImpl.test.ts
@@ -1,0 +1,111 @@
+import { DopplerLegacyClientImpl } from "./DopplerLegacyClientImpl";
+import { AxiosStatic } from "axios";
+
+const demoDopplerUserData = {
+  jwtToken: "session_token",
+  user: {
+    email: "user@email",
+    fullname: "user.fullname",
+    lang: "es",
+    avatar: {
+      text: "NN",
+      color: "#99CFB8",
+    },
+  },
+  unlayerUser: {
+    id: "user_id",
+    signature: "user_signature",
+  },
+};
+
+const createOkResponse = (data: any) => ({
+  data: {
+    ...data,
+  },
+  status: 200,
+  statusText: "OK",
+});
+
+const createBadRequestError = (data: any = {}) => {
+  const error = new Error() as any;
+  error.code = "BAD REQUEST";
+  error.response = {
+    data: {
+      ...data,
+    },
+    status: 400,
+    statusText: "BAD REQUEST",
+  };
+  return error;
+};
+
+const createSut = ({ axiosInstance }: { axiosInstance: any }) =>
+  new DopplerLegacyClientImpl({
+    axiosStatic: { create: () => axiosInstance } as unknown as AxiosStatic,
+    dopplerLegacyBaseUrl: "baseurl.fromdoppler.net",
+  });
+
+describe(DopplerLegacyClientImpl.name, () => {
+  it("should return the legacy user data when response is successful", async () => {
+    // Arrange
+    const axiosInstance = {
+      get: jest.fn(async () => createOkResponse(demoDopplerUserData)),
+    };
+
+    const sut = createSut({ axiosInstance });
+
+    // Act
+    const result = await sut.getDopplerUserData();
+
+    // Assert
+    expect(result).toEqual({
+      success: true,
+      value: { ...demoDopplerUserData },
+    });
+  });
+
+  it("should return an error object when response is not successful", async () => {
+    // Arrange
+    const axiosInstance = {
+      get: jest.fn(async () => {
+        throw createBadRequestError();
+      }),
+    };
+
+    const sut = createSut({ axiosInstance });
+
+    // Act
+    const result = await sut.getDopplerUserData();
+
+    // Assert
+    expect(result).toEqual({
+      success: false,
+      error: {
+        innerError: expect.anything(),
+        userDataNotAvailable: true,
+      },
+    });
+  });
+
+  it("should return when response is successful but data is wrong", async () => {
+    // Arrange
+    const emptyData = {};
+    const axiosInstance = {
+      get: jest.fn(async () => createOkResponse(emptyData)),
+    };
+
+    const sut = createSut({ axiosInstance });
+
+    // Act
+    const result = await sut.getDopplerUserData();
+
+    // Assert
+    expect(result).toEqual({
+      success: false,
+      error: {
+        innerError: expect.anything(),
+        userDataNotAvailable: true,
+      },
+    });
+  });
+});

--- a/src/doppler-legacy-client/DopplerLegacyClientImpl.ts
+++ b/src/doppler-legacy-client/DopplerLegacyClientImpl.ts
@@ -1,0 +1,54 @@
+import { DopplerLegacyClient, GetDopplerUserDataResult } from "./abstractions";
+import { AxiosInstance, AxiosStatic } from "axios";
+
+export class DopplerLegacyClientImpl implements DopplerLegacyClient {
+  private axios: AxiosInstance;
+
+  constructor({
+    axiosStatic,
+    dopplerLegacyBaseUrl,
+  }: {
+    axiosStatic: AxiosStatic;
+    dopplerLegacyBaseUrl: string;
+  }) {
+    this.axios = axiosStatic.create({
+      baseURL: dopplerLegacyBaseUrl,
+      withCredentials: true,
+    });
+  }
+
+  async getDopplerUserData(): Promise<GetDopplerUserDataResult> {
+    try {
+      const axiosResponse = await this.axios.get("/WebApp/GetUserData");
+      const { jwtToken, user, unlayerUser } = axiosResponse.data;
+      return {
+        success: true,
+        value: {
+          jwtToken,
+          user: {
+            email: user.email,
+            fullname: user.fullname,
+            lang: user.lang,
+            avatar: {
+              text: user.avatar.text,
+              color: user.avatar.color,
+            },
+          },
+          unlayerUser: {
+            id: unlayerUser.id,
+            signature: unlayerUser.signature,
+          },
+        },
+      };
+    } catch (error) {
+      console.error("Error loading GetUserData", error);
+      return {
+        success: false,
+        error: {
+          userDataNotAvailable: true,
+          innerError: error,
+        },
+      };
+    }
+  }
+}

--- a/src/doppler-legacy-client/abstractions.ts
+++ b/src/doppler-legacy-client/abstractions.ts
@@ -1,0 +1,29 @@
+import { Result } from "../common/abstractions";
+
+type DopplerLegacyUserData = {
+  jwtToken: string;
+  user: {
+    email: string;
+    fullname: string;
+    lang: string;
+    avatar: {
+      text: string;
+      color: string;
+    };
+  };
+  unlayerUser: { id: string; signature: string };
+};
+
+type DopplerUserDataNotAvailableError = {
+  userDataNotAvailable: true;
+  innerError: unknown;
+};
+
+export type GetDopplerUserDataResult = Result<
+  DopplerLegacyUserData,
+  DopplerUserDataNotAvailableError
+>;
+
+export interface DopplerLegacyClient {
+  getDopplerUserData: () => Promise<GetDopplerUserDataResult>;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,7 @@
 import axios from "axios";
-import { DopplerSessionState } from "./app-session/abstractions";
-import { DopplerSessionStateMonitorPollingImpl } from "./app-session/DopplerSessionStateMonitorPollingImpl";
+import { runMonitor } from "./app-session";
 import { DopplerLegacyClientDummyImpl } from "./doppler-legacy-client/DopplerLegacyClientDummyImpl";
 import { DopplerLegacyClientImpl } from "./doppler-legacy-client/DopplerLegacyClientImpl";
-import { DOPPLER_SESSION_STATE_UPDATE_EVENT_TYPE } from "./public-api";
 
 const configuration = window["doppler-session-mfe-configuration"];
 const {
@@ -19,19 +17,4 @@ const dopplerLegacyClient = useDummies
       dopplerLegacyBaseUrl,
     });
 
-const sessionStateMonitor = new DopplerSessionStateMonitorPollingImpl({
-  setInterval: window.setInterval.bind(window),
-  dopplerLegacyClient,
-  keepAliveMilliseconds,
-});
-
-sessionStateMonitor.onSessionUpdate = (sessionState: DopplerSessionState) => {
-  window.dopplerSessionState = sessionState;
-  window.dispatchEvent(
-    new CustomEvent(DOPPLER_SESSION_STATE_UPDATE_EVENT_TYPE, {
-      detail: sessionState,
-    })
-  );
-};
-
-sessionStateMonitor.start();
+runMonitor({ window, dopplerLegacyClient, keepAliveMilliseconds });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,19 @@
-console.log("doppler-session-mfe");
+import axios from "axios";
+import { DopplerLegacyClientDummyImpl } from "./doppler-legacy-client/DopplerLegacyClientDummyImpl";
+import { DopplerLegacyClientImpl } from "./doppler-legacy-client/DopplerLegacyClientImpl";
 
-export {};
+const configuration = window["doppler-session-mfe-configuration"];
+const {
+  dopplerLegacyBaseUrl = "https://app2.fromdoppler.com",
+  useDummies = true,
+} = configuration ?? {};
+
+const dopplerLegacyClient = useDummies
+  ? new DopplerLegacyClientDummyImpl()
+  : new DopplerLegacyClientImpl({
+      axiosStatic: axios,
+      dopplerLegacyBaseUrl,
+    });
+
+// TODO: use dopplerLegacyClient to test Doppler Session
+console.log({ dopplerLegacyClient });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,15 @@
 import axios from "axios";
+import { DopplerSessionState } from "./app-session/abstractions";
+import { DopplerSessionStateMonitorPollingImpl } from "./app-session/DopplerSessionStateMonitorPollingImpl";
 import { DopplerLegacyClientDummyImpl } from "./doppler-legacy-client/DopplerLegacyClientDummyImpl";
 import { DopplerLegacyClientImpl } from "./doppler-legacy-client/DopplerLegacyClientImpl";
+import { DOPPLER_SESSION_STATE_UPDATE_EVENT_TYPE } from "./public-api";
 
 const configuration = window["doppler-session-mfe-configuration"];
 const {
   dopplerLegacyBaseUrl = "https://app2.fromdoppler.com",
   useDummies = true,
+  keepAliveMilliseconds = 300000,
 } = configuration ?? {};
 
 const dopplerLegacyClient = useDummies
@@ -15,5 +19,19 @@ const dopplerLegacyClient = useDummies
       dopplerLegacyBaseUrl,
     });
 
-// TODO: use dopplerLegacyClient to test Doppler Session
-console.log({ dopplerLegacyClient });
+const sessionStateMonitor = new DopplerSessionStateMonitorPollingImpl({
+  setInterval: window.setInterval.bind(window),
+  dopplerLegacyClient,
+  keepAliveMilliseconds,
+});
+
+sessionStateMonitor.onSessionUpdate = (sessionState: DopplerSessionState) => {
+  window.dopplerSessionState = sessionState;
+  window.dispatchEvent(
+    new CustomEvent(DOPPLER_SESSION_STATE_UPDATE_EVENT_TYPE, {
+      detail: sessionState,
+    })
+  );
+};
+
+sessionStateMonitor.start();

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -1,0 +1,12 @@
+declare global {
+  interface Window {
+    "doppler-session-mfe-configuration"?: AppConfiguration;
+  }
+}
+
+interface AppConfiguration {
+  dopplerLegacyBaseUrl: string;
+  useDummies: boolean;
+}
+
+export {}

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -1,5 +1,8 @@
+import { DopplerSessionState } from "./app-session/abstractions";
+
 declare global {
   interface Window {
+    dopplerSessionState?: DopplerSessionState;
     "doppler-session-mfe-configuration"?: AppConfiguration;
   }
 }
@@ -7,6 +10,8 @@ declare global {
 interface AppConfiguration {
   dopplerLegacyBaseUrl: string;
   useDummies: boolean;
+  keepAliveMilliseconds: number;
 }
 
-export {}
+export const DOPPLER_SESSION_STATE_UPDATE_EVENT_TYPE =
+  "doppler-session-state-update";


### PR DESCRIPTION
The basic behavior of DopplerSession micro-frontend:

```mermaid
sequenceDiagram
  participant Browser
  participant DopplerSessionMFE
  participant window
  participant DopplerMVC
  Browser->>+DopplerSessionMFE: start
  DopplerSessionMFE->>window: WRITE dopplerSessionState = { status = "unknown" }
  DopplerSessionMFE-)window:dispatchEvent("doppler-session-state-update")
  alt User does not have a session in Doppler
    DopplerSessionMFE->>+DopplerMVC: GetUserData(cookie)
    DopplerMVC-->>-DopplerSessionMFE: Error
    DopplerSessionMFE->>window: WRITE dopplerSessionState = { status: "non-authenticated" }
    DopplerSessionMFE-)window: dispatchEvent("doppler-session-state-update", { status: "non-authenticated" })
  else User has a session in Doppler
    DopplerSessionMFE->>+DopplerMVC: GetUserData(cookie)
    DopplerMVC-->>-DopplerSessionMFE: UserData
    DopplerSessionMFE->>window: WRITE dopplerSessionState = { status: "authenticated", . . . }
    DopplerSessionMFE-)window: dispatchEvent("doppler-session-state-update", { status: "authenticated", . . . })
  end
  deactivate DopplerSessionMFE
  loop Each 5 min
  Browser->>+DopplerSessionMFE: interval
  alt User does not have a session in Doppler
    DopplerSessionMFE->>+DopplerMVC: GetUserData(cookie)
    DopplerMVC-->>-DopplerSessionMFE: Error
    DopplerSessionMFE->>window: WRITE dopplerSessionState = { status: "non-authenticated" }
    DopplerSessionMFE-)window: dispatchEvent("doppler-session-state-update", { status: "non-authenticated" })
  else User has a session in Doppler
    DopplerSessionMFE->>+DopplerMVC: GetUserData(cookie)
    DopplerMVC-->>-DopplerSessionMFE: UserData
    DopplerSessionMFE->>window: WRITE dopplerSessionState = { status: "authenticated", . . . }
    DopplerSessionMFE-)window: dispatchEvent("doppler-session-state-update", { status: "authenticated", . . . })
  end
  deactivate DopplerSessionMFE
  end
```

Opening a private page in a WebApp micro-frontend:

```mermaid
sequenceDiagram
  participant Browser
  participant WebAppMFE
  participant window
  Browser->>+WebAppMFE: start
  WebAppMFE-)window: addEventListener ("doppler-session-state-update", . . .)
  alt WebAppMFE loaded before DopplerSessionMFE be ready
    WebAppMFE->>+window: READ dopplerSessionState
    window-->>-WebAppMFE: undefined [*]
    Note right of WebAppMFE: Assumes { status = "unknown" }
  else DopplerSessionMFE was ready before load WebAppMFE
    WebAppMFE->>+window: READ dopplerSessionState
    window-->>-WebAppMFE: { status = "unknown" } [*]
  end
  WebAppMFE-->>-Browser: Show spinner
  alt WebAppMFE loaded before DopplerSessionMFE be ready
    window->>+WebAppMFE: on "doppler-session-state-update"
    WebAppMFE->>+window: READ dopplerSessionState
    window-->>-WebAppMFE: { status = "unknown" } [*]
    WebAppMFE-->>-Browser: Show spinner
  end
  alt User does not have a session in Doppler
    window->>+WebAppMFE: on "doppler-session-state-update"
    WebAppMFE->>+window: READ dopplerSessionState
    window-->>-WebAppMFE: { status = "non-authenticated" }
    WebAppMFE-->>-Browser: Redirect to Login
  else User has a session in Doppler
    window->>+WebAppMFE: on "doppler-session-state-update"
    WebAppMFE->>+window: READ dopplerSessionState
    window-->>-WebAppMFE: { status = "authenticated", . . . }
    WebAppMFE-->>-Browser: Render the page
  end
```

`[*]` At the moment, the first answers for `READ dopplerSessionState` will always
be `null` or `{ status = "unknown" }`. But in the future, _DopplerSession micro-
frontend_ is going to be improved to cache the last session state (for example,
in local storage), so the first steps could be omitted.

Pending:

- [x] Add more details to this description
- [x] Update README.MD with the `dopplerSession` global object documentation
- [x] Add tests