### PR TITLE
fix: restore unknown status while session monitor initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ sequenceDiagram
   participant DopplerMVC
 
   Browser->>+DopplerSessionMFE: start
+  DopplerSessionMFE->>window: WRITE dopplerSessionState = undefined
+  DopplerSessionMFE-)window:dispatchEvent("doppler-session-state-update")
   alt User does not have a session in Doppler
     DopplerSessionMFE->>+DopplerMVC: GetUserData(cookie)
     DopplerMVC-->>-DopplerSessionMFE: Error
@@ -55,7 +57,12 @@ sequenceDiagram
   WebAppMFE->>+window: READ dopplerSessionState
   window-->>-WebAppMFE: READ undefined [*]
   WebAppMFE-->>-Browser: Show spinner
-
+  alt WebAppMFE loaded before DopplerSessionMFE be ready
+    window->>+WebAppMFE: on "doppler-session-state-update"
+    WebAppMFE->>+window: READ dopplerSessionState
+    window-->>-WebAppMFE: READ undefined [*]
+    WebAppMFE-->>-Browser: Show spinner
+  end
   alt User does not have a session in Doppler
     window->>+WebAppMFE: on "doppler-session-state-update"
     WebAppMFE->>+window: READ dopplerSessionState
@@ -70,6 +77,6 @@ sequenceDiagram
 ```
 
 `[*]` At the moment, the first answers for `READ dopplerSessionState` will always
-be `null`. But in the future, _DopplerSession micro-frontend_ is going to be improved
+be `undefined`. But in the future, _DopplerSession micro-frontend_ is going to be improved
 to cache the last session state (for example, in local storage), so the first steps
 could be omitted.

--- a/src/app-session/DopplerSessionStateMonitorPollingImpl.ts
+++ b/src/app-session/DopplerSessionStateMonitorPollingImpl.ts
@@ -53,6 +53,12 @@ export class DopplerSessionStateMonitorPollingImpl
   }
 
   async start(): Promise<void> {
+    // It allows WebApp's login to redirect to authenticated pages even when we
+    // still does not know the real session state.
+    // If we call this arbitrarily in a authenticated state, it will temporarily
+    // set the session state to unknown.
+    this.onSessionUpdate(undefined);
+
     this._intervalID = this._setInterval(async () => {
       const userData = await this.fetchDopplerUserData();
       if (!this._disposed) {

--- a/src/app-session/index.test.tsx
+++ b/src/app-session/index.test.tsx
@@ -120,7 +120,7 @@ describe(runMonitor.name, () => {
     // to the server response for getDopplerUserData.
     expect(dopplerLegacyClient.getDopplerUserData).toHaveBeenCalledTimes(1);
     expect(window.dopplerSessionState).toBeUndefined();
-    expect(window.dispatchEvent).toHaveBeenCalledTimes(0);
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
 
     // Act
     // Server responds successfully for getDopplerUserData
@@ -138,7 +138,7 @@ describe(runMonitor.name, () => {
       lang: demoDopplerUserData.user.lang,
       rawDopplerUserData: demoDopplerUserData,
     });
-    expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(2);
     expect(lastDispatchedEventRef.value).toBeInstanceOf(CustomEvent);
     expect(lastDispatchedEventRef.value.type).toBe(
       "doppler-session-state-update"
@@ -160,7 +160,7 @@ describe(runMonitor.name, () => {
       lang: demoDopplerUserData.user.lang,
       rawDopplerUserData: demoDopplerUserData,
     });
-    expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(2);
 
     // Act
     // Server responds with an error for getDopplerUserData, for example if the
@@ -173,7 +173,7 @@ describe(runMonitor.name, () => {
     expect(window.dopplerSessionState).toEqual({
       status: "non-authenticated",
     });
-    expect(window.dispatchEvent).toHaveBeenCalledTimes(2);
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(3);
     expect(lastDispatchedEventRef.value).toBeInstanceOf(CustomEvent);
     expect(lastDispatchedEventRef.value.type).toBe(
       "doppler-session-state-update"
@@ -202,7 +202,7 @@ describe(runMonitor.name, () => {
 
     expect(dopplerLegacyClient.getDopplerUserData).toHaveBeenCalledTimes(1);
     expect(window.dopplerSessionState).toBeUndefined();
-    expect(window.dispatchEvent).toHaveBeenCalledTimes(0);
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
 
     // Act
     monitor.stopAndDispose();
@@ -251,7 +251,7 @@ describe(runMonitor.name, () => {
     runIntervalEvent();
 
     expect(window.dopplerSessionState?.status).toBe("authenticated");
-    expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(2);
     expect(dopplerLegacyClient.getDopplerUserData).toHaveBeenCalledTimes(2);
 
     // Act
@@ -295,7 +295,7 @@ describe(runMonitor.name, () => {
     // Server responds with success
     await resolveGetDopplerUserDataWithTheNextResult();
     expect(window.dopplerSessionState?.status).toBe("authenticated");
-    expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(2);
     expect(dopplerLegacyClient.getDopplerUserData).toHaveBeenCalledTimes(1);
 
     // Act
@@ -310,7 +310,7 @@ describe(runMonitor.name, () => {
     await resolveGetDopplerUserDataWithTheNextResult();
     // Status is still authenticated
     expect(window.dopplerSessionState?.status).toBe("authenticated");
-    expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(window.dispatchEvent).toHaveBeenCalledTimes(2);
     expect(dopplerLegacyClient.getDopplerUserData).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
It fixes this issue:

![2022-08-16_16-21-00 (1)](https://user-images.githubusercontent.com/1157864/184964737-7fd15685-b844-4c5b-9ac9-bf780069d3f2.gif)

![image](https://user-images.githubusercontent.com/1157864/184965335-2e1beb92-bc9c-4a7d-adf8-fd971c452eaf.png)

When the `restart()` is executed, the session state should be _authenticated_ or _unknown_. 

In another case, the redirection to authenticated pages will fail, redirecting back to the login.

This is the undesired effect: 

![2022-08-16_16-31-52 (1)](https://user-images.githubusercontent.com/1157864/184966337-4bac3700-4954-479e-bcb5-8d8074dc6529.gif)

But this is not a real scenario yet.