### PR TITLE
build: auto-merge Renovate PRs using GitHub

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     ":prConcurrentLimit20",
     "group:dotNetCore"
   ],
+  "platformAutomerge": true,
   "packageRules": [
     {
       "packageRules": [


### PR DESCRIPTION
I already tested it in https://github.com/FromDoppler/doppler-editors-webapp/pull/557 and works great!

It will avoid keeping the auto-merge PRs open so much time and rebasing them fewer times.